### PR TITLE
Updated script and test-workflow.yml

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -35,7 +35,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: Build with Maven
-        run: mvn -B package --file pom.xml
+        run: mvn -B clean test --file pom.xml
 
       - name: Copy JAR files to new Directory  
         run: mkdir output && cp target/$(grep -o "<artifactId>.*</artifactId>" pom.xml | head -1 | sed "s#<artifactId>###\g" | sed "s#</artifactId>###\g")-$(grep -o "<version>.*</version>" pom.xml | head -1 | sed "s#<version>###\g" | sed "s#</version>###\g").jar output

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -35,7 +35,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: Build with Maven
-        run: mvn -B clean test --file pom.xml
+        run: mvn -B clean test package --file pom.xml
 
       - name: Copy JAR files to new Directory  
         run: mkdir output && cp target/$(grep -o "<artifactId>.*</artifactId>" pom.xml | head -1 | sed "s#<artifactId>###\g" | sed "s#</artifactId>###\g")-$(grep -o "<version>.*</version>" pom.xml | head -1 | sed "s#<version>###\g" | sed "s#</version>###\g").jar output

--- a/scripts/generate-reports.sh
+++ b/scripts/generate-reports.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-allure generate docs/allure-results --clean -o docs/allure-reports && echo "GENERATED REPORT"
+../.allure/allure-2.8.1/bin/allure generate docs/allure-results --clean -o docs/allure-reports && echo "GENERATED REPORT"


### PR DESCRIPTION
The generate-reports.sh script now points to the allure executable in .allure/allure-2.8.1/bin/allure
The test-workflow.yml now uses mvn -B clean test --file pom.xml in order to allow the pom.xml's usage of the maven exec plugin.